### PR TITLE
Add option to choose SentenceTransformer model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ DB_PORT=3306
 DB_USERNAME=
 DB_PASSWORD=
 DB_DATABASE=
+MODEL_NAME="jinaai/jina-embeddings-v3"

--- a/src/similarity_matrix/lib/matrix.py
+++ b/src/similarity_matrix/lib/matrix.py
@@ -74,7 +74,7 @@ class SimilarityMatrix:
                 (len(row_ids), len(column_ids)), dtype=float)
             
         # Store the model name for later use
-        self.model_name = model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')
+        self.model_name = model_name if model_name is not None else 'jinaai/jina-embeddings-v3'
 
         # These values are updated automatically right before matrix computation
         # do not set them manually! They are private for a reason
@@ -108,7 +108,7 @@ class SimilarityMatrix:
             name,
             row_load_function,
             column_load_function,
-            model_name= model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'))
+            model_name= model_name if model_name is not None else 'jinaai/jina-embeddings-v3')
 
     def calculate(self, fake: int | None = None) -> None:
         """
@@ -207,7 +207,7 @@ class SimilarityMatrix:
     def load(cls, 
              directory_path: Union[str, Path],
              name: str, 
-             model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')) -> 'SimilarityMatrix':
+             model_name: str | None = None) -> 'SimilarityMatrix':
         """
         Load the matrix and indices from files in the specified directory.
 

--- a/src/similarity_matrix/lib/matrix.py
+++ b/src/similarity_matrix/lib/matrix.py
@@ -1,5 +1,6 @@
 import numpy as np
 import json
+import os
 from typing import List, Optional, Union
 from pathlib import Path
 
@@ -31,7 +32,7 @@ class SimilarityMatrix:
                  row_load_function: callable = None,
                  column_load_function: callable = None,
                  matrix: Optional[np.ndarray] = None,
-                 model_name: str = "jinaai/jina-embeddings-v3"):
+                 model_name: str | None = None):
         """
         Initialize the SymilarityMatrix.
 
@@ -73,7 +74,7 @@ class SimilarityMatrix:
                 (len(row_ids), len(column_ids)), dtype=float)
             
         # Store the model name for later use
-        self.model_name = model_name
+        self.model_name = model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')
 
         # These values are updated automatically right before matrix computation
         # do not set them manually! They are private for a reason
@@ -88,7 +89,7 @@ class SimilarityMatrix:
             name: str,
             row_load_function: callable = None,
             column_load_function: callable = None,
-            model_name: str = "jinaai/jina-embeddings-v3"):
+            model_name: str | None = None):
         """
         Create an empty SymilarityMatrix with just the row and column lists.
 
@@ -107,7 +108,7 @@ class SimilarityMatrix:
             name,
             row_load_function,
             column_load_function,
-            model_name=model_name)
+            model_name= model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'))
 
     def calculate(self, fake: int | None = None) -> None:
         """
@@ -203,8 +204,10 @@ class SimilarityMatrix:
         logger.debug(f"Saved indices to {indices_path}")
 
     @classmethod
-    def load(cls, directory_path: Union[str, Path],
-             name: str, model_name: str = "jinaai/jina-embeddings-v3") -> 'SimilarityMatrix':
+    def load(cls, 
+             directory_path: Union[str, Path],
+             name: str, 
+             model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')) -> 'SimilarityMatrix':
         """
         Load the matrix and indices from files in the specified directory.
 

--- a/src/similarity_matrix/lib/matrix.py
+++ b/src/similarity_matrix/lib/matrix.py
@@ -30,7 +30,8 @@ class SimilarityMatrix:
                  name: str,
                  row_load_function: callable = None,
                  column_load_function: callable = None,
-                 matrix: Optional[np.ndarray] = None):
+                 matrix: Optional[np.ndarray] = None,
+                 model_name: str = "jinaai/jina-embeddings-v3"):
         """
         Initialize the SymilarityMatrix.
 
@@ -40,7 +41,8 @@ class SimilarityMatrix:
             name: Name of the matrix (used for file saving)
             row_load_function: Function to load rows given the row IDs
             column_load_function: Function to load columns given the column IDs
-            matrix: Optional pre-computed matrix. If None, creates empty matrix.
+            matrix: Optional pre-computed matrix. If None, creates empty matrix
+            model_name: The name of the SentenceTransformer model to initialize.
         """
         self.row_ids = list(row_ids)
         self.column_ids = list(column_ids)
@@ -69,6 +71,9 @@ class SimilarityMatrix:
             # Initialize empty matrix with zeros
             self.matrix = np.zeros(
                 (len(row_ids), len(column_ids)), dtype=float)
+            
+        # Store the model name for later use
+        self.model_name = model_name
 
         # These values are updated automatically right before matrix computation
         # do not set them manually! They are private for a reason
@@ -82,7 +87,8 @@ class SimilarityMatrix:
             column_ids: list,
             name: str,
             row_load_function: callable = None,
-            column_load_function: callable = None):
+            column_load_function: callable = None,
+            model_name: str = "jinaai/jina-embeddings-v3"):
         """
         Create an empty SymilarityMatrix with just the row and column lists.
 
@@ -90,6 +96,7 @@ class SimilarityMatrix:
             row_ids: List of row IDs
             column_ids: List of column IDs
             name: Name of the matrix
+            model_name: The name of the SentenceTransformer model to initialize.
 
         Returns:
             SymilarityMatrix instance with zero-initialized matrix
@@ -99,7 +106,8 @@ class SimilarityMatrix:
             column_ids,
             name,
             row_load_function,
-            column_load_function)
+            column_load_function,
+            model_name=model_name)
 
     def calculate(self, fake: int | None = None) -> None:
         """
@@ -117,7 +125,7 @@ class SimilarityMatrix:
             return
 
         # Initialize the embedding model
-        model = initialize_model()
+        model = initialize_model(model_name=self.model_name)
 
         # Load row and column data using the passed functions
         row_texts = self.row_load_function()
@@ -196,13 +204,14 @@ class SimilarityMatrix:
 
     @classmethod
     def load(cls, directory_path: Union[str, Path],
-             name: str) -> 'SimilarityMatrix':
+             name: str, model_name: str = "jinaai/jina-embeddings-v3") -> 'SimilarityMatrix':
         """
         Load the matrix and indices from files in the specified directory.
 
         Args:
             directory_path: Directory path where files are located
             name: Name of the matrix files to load
+            model_name: The name of the SentenceTransformer model to initialize.
 
         Returns:
             SymilarityMatrix instance loaded from files
@@ -227,7 +236,7 @@ class SimilarityMatrix:
         row_ids = indices_data['row_ids']
         column_ids = indices_data['column_ids']
 
-        return cls(row_ids, column_ids, loaded_name, matrix=matrix)
+        return cls(row_ids, column_ids, loaded_name, matrix=matrix, model_name=model_name)
 
     def get_value(self, row_id: str, column_id: str) -> float:
         """
@@ -295,7 +304,8 @@ class SimilarityMatrix:
             name=self.name,
             matrix=normalize_array(self.matrix, min_v, max_v),
             row_load_function=self.row_load_function,
-            column_load_function=self.column_load_function)
+            column_load_function=self.column_load_function,
+            model_name=self.model_name)
 
     @property
     def shape(self) -> tuple:

--- a/src/similarity_matrix/lib/matrix_chunk.py
+++ b/src/similarity_matrix/lib/matrix_chunk.py
@@ -29,6 +29,7 @@ class ChunkedSimilarityMatrix(SimilarityMatrix):
                  row_load_function: callable = None,
                  column_load_function: callable = None,
                  matrix: Optional[np.ndarray] = None,
+                 model_name: str = "jinaai/jina-embeddings-v3",
                  row_chunk_size: int = 100,
                  column_chunk_size: int = 100,
                  temp_dir: Optional[Union[str, Path]] = None):
@@ -42,12 +43,13 @@ class ChunkedSimilarityMatrix(SimilarityMatrix):
             row_load_function: Function to load row data
             column_load_function: Function to load column data
             matrix: Optional pre-computed matrix
+            model_name: The name of the SentenceTransformer model to initialize
             row_chunk_size: Number of rows to process at once
             column_chunk_size: Number of columns to process at once
             temp_dir: Directory for temporary files (uses system temp if None)
         """
         super().__init__(row_ids, column_ids, name, row_load_function,
-                         column_load_function, matrix)
+                         column_load_function, matrix, model_name)
 
         self.row_chunk_size = row_chunk_size
         self.column_chunk_size = column_chunk_size
@@ -66,7 +68,7 @@ class ChunkedSimilarityMatrix(SimilarityMatrix):
             return
 
         # Initialize the embedding model
-        model = initialize_model()
+        model = initialize_model(model_name=self.model_name)
 
         # Load row and column data using the passed functions
         row_texts = self.row_load_function()

--- a/src/similarity_matrix/lib/matrix_chunk.py
+++ b/src/similarity_matrix/lib/matrix_chunk.py
@@ -29,7 +29,7 @@ class ChunkedSimilarityMatrix(SimilarityMatrix):
                  row_load_function: callable = None,
                  column_load_function: callable = None,
                  matrix: Optional[np.ndarray] = None,
-                 model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'),
+                 model_name: str = 'jinaai/jina-embeddings-v3',
                  row_chunk_size: int = 100,
                  column_chunk_size: int = 100,
                  temp_dir: Optional[Union[str, Path]] = None):

--- a/src/similarity_matrix/lib/matrix_chunk.py
+++ b/src/similarity_matrix/lib/matrix_chunk.py
@@ -29,7 +29,7 @@ class ChunkedSimilarityMatrix(SimilarityMatrix):
                  row_load_function: callable = None,
                  column_load_function: callable = None,
                  matrix: Optional[np.ndarray] = None,
-                 model_name: str = "jinaai/jina-embeddings-v3",
+                 model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'),
                  row_chunk_size: int = 100,
                  column_chunk_size: int = 100,
                  temp_dir: Optional[Union[str, Path]] = None):

--- a/src/similarity_matrix/lib/model.py
+++ b/src/similarity_matrix/lib/model.py
@@ -40,7 +40,7 @@ def get_model_size(model, float_bit=32):
 
 
 def initialize_model(
-        model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'),
+        model_name: str = 'jinaai/jina-embeddings-v3',
         use_cuda: bool = True,
         force_sentence_transformer: bool = False,
         **kwargs) -> SentenceTransformer:

--- a/src/similarity_matrix/lib/model.py
+++ b/src/similarity_matrix/lib/model.py
@@ -40,7 +40,7 @@ def get_model_size(model, float_bit=32):
 
 
 def initialize_model(
-        model_name: str = "jinaai/jina-embeddings-v3",
+        model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'),
         use_cuda: bool = True,
         force_sentence_transformer: bool = False,
         **kwargs) -> SentenceTransformer:

--- a/src/similarity_matrix/lib/pipeline.py
+++ b/src/similarity_matrix/lib/pipeline.py
@@ -60,13 +60,13 @@ class Pipeline(ABC):
             db: Database,
             path: str = './matrices',
             chunk_size: int | None = None,
-            model_name: str = "jinaai/jina-embeddings-v3",):
+            model_name: str | None = None):
         self.name = name
         self.db = db
         self.path = path
         self.chunk_size = chunk_size
         self._sm = None
-        self.model_name = model_name
+        self.model_name = model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')
 
         if not os.path.isdir(self.path):
             os.mkdir(self.path)

--- a/src/similarity_matrix/lib/pipeline.py
+++ b/src/similarity_matrix/lib/pipeline.py
@@ -59,12 +59,14 @@ class Pipeline(ABC):
             name: str,
             db: Database,
             path: str = './matrices',
-            chunk_size: int | None = None):
+            chunk_size: int | None = None,
+            model_name: str = "jinaai/jina-embeddings-v3",):
         self.name = name
         self.db = db
         self.path = path
         self.chunk_size = chunk_size
         self._sm = None
+        self.model_name = model_name
 
         if not os.path.isdir(self.path):
             os.mkdir(self.path)
@@ -140,6 +142,7 @@ class Pipeline(ABC):
                 name=self.name,
                 row_load_function=self.get_row_values,
                 column_load_function=self.get_column_values,
+                model_name=self.model_name,
                 row_chunk_size=self.chunk_size,
                 column_chunk_size=self.chunk_size)
         else:
@@ -149,7 +152,8 @@ class Pipeline(ABC):
                 column_ids=self.get_column_ids(),
                 name=self.name,
                 row_load_function=self.get_row_values,
-                column_load_function=self.get_column_values)
+                column_load_function=self.get_column_values,
+                model_name=self.model_name)
 
     def get_matrix(self) -> SimilarityMatrix:
         """

--- a/src/similarity_matrix/lib/pipeline.py
+++ b/src/similarity_matrix/lib/pipeline.py
@@ -66,7 +66,7 @@ class Pipeline(ABC):
         self.path = path
         self.chunk_size = chunk_size
         self._sm = None
-        self.model_name = model_name if model_name is not None else os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')
+        self.model_name = model_name if model_name is not None else 'jinaai/jina-embeddings-v3'
 
         if not os.path.isdir(self.path):
             os.mkdir(self.path)

--- a/src/similarity_matrix/main.py
+++ b/src/similarity_matrix/main.py
@@ -74,6 +74,11 @@ def main():
         default=os.environ.get('DB_PASSWORD'),
         help='database password (can be passed through .env DB_PASSWORD)')
     parser.add_argument(
+        '--model-name',
+        metavar='MODEL_NAME',
+        default=os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3'),
+        help='the name of the model to use for the similarity calculation (default: jinaai/jina-embeddings-v3, can be passed through .env MODEL_NAME)')
+    parser.add_argument(
         '--pipeline-dir',
         default='./pipelines',
         help='path to the directory containing all pipelines (default: ./pipelines)')
@@ -194,6 +199,7 @@ def main():
         name=args.pipeline,
         db=db,
         path=args.output_dir,
+        model_name=args.model_name
     )
 
     # ---------------------------------------

--- a/tests/reskill/lib/test_modelname.py
+++ b/tests/reskill/lib/test_modelname.py
@@ -1,0 +1,234 @@
+import json
+import pytest
+import numpy as np
+from unittest.mock import patch, MagicMock
+from similarity_matrix.lib.matrix import SimilarityMatrix
+from similarity_matrix.lib.matrix_chunk import ChunkedSimilarityMatrix
+
+@pytest.fixture
+def basic_ids():
+    return ["r1"],["c1"]
+
+@pytest.fixture
+def fake_load_functions():
+    return (
+        lambda: ["text1"],
+        lambda: ["text2"]
+    )
+
+class TestModelName:
+    ## --------------------------------------------------------------
+    ## SimilarityMatrix model_name tests
+    ## --------------------------------------------------------------
+
+    # Verify that model_name was appropriately stored by the 
+    # SimilarityMatrix class.
+    def test_similarity_matrix_model_name_stored(self, basic_ids):
+        row_ids, column_ids = basic_ids
+        matrix = SimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test",
+            model_name="test-model"
+        )
+
+        assert matrix.model_name == "test-model"
+
+    # Ensure that when no model_name is provided, SimilarityMatrix 
+    # assigns the correct default value.
+    def test_similarity_matrix_default_model_name(self, basic_ids):
+        row_ids, column_ids = basic_ids
+        matrix = SimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test"
+        )
+
+        assert matrix.model_name == "jinaai/jina-embeddings-v3"
+
+    # Verify that model_name is passed to initialize_model() when 
+    # calculate() is called.
+    @patch("similarity_matrix.lib.matrix.cos_sim_mem")
+    @patch("similarity_matrix.lib.matrix.initialize_model")
+    def test_similarity_matrix_model_name_passed_to_initialize(
+            self,
+            mock_initialize,
+            mock_cos_sim,
+            basic_ids,
+            fake_load_functions):
+
+        mock_initialize.return_value = MagicMock()
+        mock_cos_sim.return_value = np.array([[0.5]])
+
+        row_ids, column_ids = basic_ids
+        row_loader, column_loader = fake_load_functions
+
+        matrix = SimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test",
+            row_load_function=row_loader,
+            column_load_function=column_loader,
+            model_name="test-model"
+        )
+
+        matrix.calculate()
+
+        mock_initialize.assert_called_once_with(model_name="test-model")
+
+    # Checks that an empty matrix is created with zero values, 
+    # correct IDs, and a custom model_name
+    def test_create_empty_with_custom_model_name(self, basic_ids):
+        row_ids, column_ids = basic_ids
+
+        matrix = SimilarityMatrix.create_empty(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="empty_custom",
+            model_name="test-model"
+        )
+
+        # Controlli
+        assert matrix.shape == (1, 1)
+        assert np.all(matrix.matrix == 0)
+        assert matrix.row_ids == row_ids
+        assert matrix.column_ids == column_ids
+        assert matrix.model_name == "test-model"
+
+    # Checks that an empty matrix is created with zero values, 
+    # correct IDs, and the default model_name
+    def test_create_empty_with_default_model_name(self, basic_ids):
+        row_ids, column_ids = basic_ids
+
+        matrix = SimilarityMatrix.create_empty(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="empty_default"
+        )
+
+        # Controlli
+        assert matrix.shape == (1, 1)
+        assert np.all(matrix.matrix == 0)
+        assert matrix.row_ids == row_ids
+        assert matrix.column_ids == column_ids
+        assert matrix.model_name == "jinaai/jina-embeddings-v3"
+
+    # Verifies that loading a saved matrix restores data and IDs while ù
+    # keeping a custom model_name
+    def test_load_preserves_custom_model_name(self, tmp_path, basic_ids):
+        # Setup matrix e JSON file
+        row_ids, column_ids = basic_ids
+        matrix_data = np.array([[0.42]])
+        name = "test_matrix"
+        
+        # Save matrix and json in a temporary directory
+        np.save(tmp_path / f"{name}.npy", matrix_data)
+        with open(tmp_path / f"{name}.json", "w") as f:
+            json.dump({
+                "name": name,
+                "row_ids": row_ids,
+                "column_ids": column_ids
+            }, f)
+        
+        # Load matrix with custom model_name
+        loaded_matrix = SimilarityMatrix.load(
+            directory_path=tmp_path,
+            name=name,
+            model_name="test-model"
+        )
+        
+        assert loaded_matrix.model_name == "test-model"
+
+        # Check that the loaded matrix data and IDs match what was saved
+        assert np.array_equal(loaded_matrix.matrix, matrix_data)
+        assert loaded_matrix.row_ids == row_ids
+        assert loaded_matrix.column_ids == column_ids
+
+    # Verifies that loading a saved matrix without specifying model_name 
+    # assigns the default value while restoring data and IDs
+    def test_load_uses_default_model_name_if_not_specified(self, tmp_path, basic_ids):
+        # Setup matrix e file JSON
+        row_ids, column_ids = basic_ids
+        matrix_data = np.array([[0.42]])
+        name = "test_matrix_default"
+        
+        np.save(tmp_path / f"{name}.npy", matrix_data)
+        with open(tmp_path / f"{name}.json", "w") as f:
+            json.dump({
+                "name": name,
+                "row_ids": row_ids,
+                "column_ids": column_ids
+            }, f)
+        
+        # Carica senza specificare model_name
+        loaded_matrix = SimilarityMatrix.load(
+            directory_path=tmp_path,
+            name=name
+        )
+        
+        assert loaded_matrix.model_name == "jinaai/jina-embeddings-v3"
+        assert np.array_equal(loaded_matrix.matrix, matrix_data)
+        assert loaded_matrix.row_ids == row_ids
+        assert loaded_matrix.column_ids == column_ids
+    
+    ## --------------------------------------------------------------
+    ## ChunkedSimilarityMatrix model_name tests
+    ## --------------------------------------------------------------
+
+    # Verify that model_name was appropriately stored by the 
+    # ChunkedSimilarityMatrix class.
+    def test_chunked_matrix_model_name_stored(self, basic_ids):
+        row_ids, column_ids = basic_ids
+
+        matrix = ChunkedSimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test",
+            model_name="custom-model"
+        )
+
+        assert matrix.model_name == "custom-model"
+
+    # Ensure that when no model_name is provided, ChunkedSimilarityMatrix 
+    # assigns the correct default value.
+    def test_chunked_matrix_default_model_name(self, basic_ids):
+        """Verifica valore di default."""
+        row_ids, column_ids = basic_ids
+
+        matrix = ChunkedSimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test"
+        )
+
+        assert matrix.model_name == "jinaai/jina-embeddings-v3"
+
+    # Verify that model_name is passed to initialize_model() when 
+    # calculate() is called.
+    @patch("similarity_matrix.lib.matrix_chunk.cos_sim_mem")
+    @patch("similarity_matrix.lib.matrix_chunk.initialize_model")
+    def test_chunked_matrix_model_name_passed_to_initialize(
+            self,
+            mock_initialize,
+            mock_cos_sim,
+            basic_ids,
+            fake_load_functions):
+
+        mock_initialize.return_value = MagicMock()
+        mock_cos_sim.return_value = np.array([[0.5]])
+
+        row_ids, column_ids = basic_ids
+        row_loader, column_loader = fake_load_functions
+
+        matrix = ChunkedSimilarityMatrix(
+            row_ids=row_ids,
+            column_ids=column_ids,
+            name="test",
+            row_load_function=row_loader,
+            column_load_function=column_loader,
+            model_name="test-model"
+        )
+
+        matrix.calculate()
+
+        mock_initialize.assert_called_once_with(model_name="test-model")

--- a/tests/reskill/lib/test_modelname.py
+++ b/tests/reskill/lib/test_modelname.py
@@ -280,6 +280,7 @@ class TestModelName:
     ## Pipiline model_name tests
     ## --------------------------------------------------------------
 
+    # Verify that model_name is stored in the Pipeline
     def test_pipeline_model_name_stored(self):
         db_mock = MagicMock()
         pipeline = ConcretePipeline(
@@ -290,6 +291,8 @@ class TestModelName:
 
         assert pipeline.model_name == "test-model"
 
+    # Verify that if no model_name is provided, the Pipeline assigns 
+    # the default value
     def test_pipeline_default_model_name(self):
         db_mock = MagicMock()
         pipeline = ConcretePipeline(
@@ -299,6 +302,8 @@ class TestModelName:
 
         assert pipeline.model_name == "jinaai/jina-embeddings-v3"
 
+    # Verify that when a Pipeline is initialized, it passes the model_name
+    # to the SimilarityMatrix it creates (when chunk_size is None)
     @patch("similarity_matrix.lib.pipeline.SimilarityMatrix.create_empty")
     def test_pipeline_passes_model_name_to_similarity_matrix(self, mock_create):
         db_mock = MagicMock()
@@ -315,6 +320,8 @@ class TestModelName:
         _, kwargs = mock_create.call_args
         assert kwargs["model_name"] == "test-model"
 
+    # Verify that when a Pipeline is initialized, it passes the model_name
+    # to the ChunkedSimilarityMatrix it creates (when chunk_size is set)
     @patch("similarity_matrix.lib.pipeline.ChunkedSimilarityMatrix")
     def test_pipeline_passes_model_name_to_chunked_matrix(self, mock_chunked):
         db_mock = MagicMock()

--- a/tests/reskill/lib/test_modelname.py
+++ b/tests/reskill/lib/test_modelname.py
@@ -28,7 +28,7 @@ class ConcretePipeline(Pipeline):
             db: Database, 
             path: str = './matrices', 
             chunk_size: int | None = None,
-            model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')):
+            model_name: str = 'jinaai/jina-embeddings-v3'):
         super().__init__(name, db, path, chunk_size=chunk_size, model_name=model_name)
         self.row_ids = [1, 2, 3]
         self.column_ids = [10, 20, 30]

--- a/tests/reskill/lib/test_modelname.py
+++ b/tests/reskill/lib/test_modelname.py
@@ -1,9 +1,12 @@
+import os
 import json
 import pytest
 import numpy as np
 from unittest.mock import patch, MagicMock
 from similarity_matrix.lib.matrix import SimilarityMatrix
 from similarity_matrix.lib.matrix_chunk import ChunkedSimilarityMatrix
+from similarity_matrix.lib.pipeline import Pipeline
+from similarity_matrix.lib.database import Database
 
 @pytest.fixture
 def basic_ids():
@@ -15,6 +18,46 @@ def fake_load_functions():
         lambda: ["text1"],
         lambda: ["text2"]
     )
+
+class ConcretePipeline(Pipeline):
+    """Concrete implementation of Pipeline for testing purposes."""
+
+    def __init__(
+            self, 
+            name: str, 
+            db: Database, 
+            path: str = './matrices', 
+            chunk_size: int | None = None,
+            model_name: str = os.environ.get('MODEL_NAME', 'jinaai/jina-embeddings-v3')):
+        super().__init__(name, db, path, chunk_size=chunk_size, model_name=model_name)
+        self.row_ids = [1, 2, 3]
+        self.column_ids = [10, 20, 30]
+        self.row_values = ["text1", "text2", "text3"]
+        self.column_values = ["textA", "textB", "textC"]
+
+    def get_row_ids(self) -> list:
+        return self.row_ids
+
+    def get_column_ids(self) -> list:
+        return self.column_ids
+
+    def get_row_values(self) -> list[str]:
+        return self.row_values
+
+    def get_column_values(self) -> list[str]:
+        return self.column_values
+
+    def update_db_row_table(self):
+        # Just mock method
+        pass
+
+    def update_db_column_table(self):
+        # Just mock method
+        pass
+
+    def update_db_matrix_table(self):
+        # Just mock method
+        pass
 
 class TestModelName:
     ## --------------------------------------------------------------
@@ -232,3 +275,58 @@ class TestModelName:
         matrix.calculate()
 
         mock_initialize.assert_called_once_with(model_name="test-model")
+
+    ## --------------------------------------------------------------
+    ## Pipiline model_name tests
+    ## --------------------------------------------------------------
+
+    def test_pipeline_model_name_stored(self):
+        db_mock = MagicMock()
+        pipeline = ConcretePipeline(
+            name="test",
+            db=db_mock,
+            model_name="test-model"
+        )
+
+        assert pipeline.model_name == "test-model"
+
+    def test_pipeline_default_model_name(self):
+        db_mock = MagicMock()
+        pipeline = ConcretePipeline(
+            name="test",
+            db=db_mock
+        )
+
+        assert pipeline.model_name == "jinaai/jina-embeddings-v3"
+
+    @patch("similarity_matrix.lib.pipeline.SimilarityMatrix.create_empty")
+    def test_pipeline_passes_model_name_to_similarity_matrix(self, mock_create):
+        db_mock = MagicMock()
+
+        pipeline = ConcretePipeline(
+            name="test",
+            db=db_mock,
+            model_name="test-model"
+        )
+
+        pipeline.chunk_size = None
+        pipeline._init_matrix()
+
+        _, kwargs = mock_create.call_args
+        assert kwargs["model_name"] == "test-model"
+
+    @patch("similarity_matrix.lib.pipeline.ChunkedSimilarityMatrix")
+    def test_pipeline_passes_model_name_to_chunked_matrix(self, mock_chunked):
+        db_mock = MagicMock()
+
+        pipeline = ConcretePipeline(
+            name="test",
+            db=db_mock,
+            model_name="test-model",
+            chunk_size=10
+        )
+
+        pipeline._init_matrix()
+
+        _, kwargs = mock_chunked.call_args
+        assert kwargs["model_name"] == "test-model"

--- a/tests/reskill/lib/test_pipeline.py
+++ b/tests/reskill/lib/test_pipeline.py
@@ -164,7 +164,8 @@ class TestPipeline:
             column_ids=[10, 20, 30],
             name=pipeline.name,
             row_load_function=pipeline.get_row_values,
-            column_load_function=pipeline.get_column_values
+            column_load_function=pipeline.get_column_values,
+            model_name=pipeline.model_name
         )
 
         # Verify the matrix was calculated and saved

--- a/tests/reskill/test_main.py
+++ b/tests/reskill/test_main.py
@@ -483,6 +483,7 @@ class TestIntegration:
             '--db-name', 'test_db',
             '--db-user', 'test_user',
             '--db-password', 'test_pass',
+            '--model-name', 'test-model',
             '--pipeline-dir', 'test/pipelines',
             '--output-dir', 'test/output',
             '--pipeline', 'test_pipeline',
@@ -508,7 +509,8 @@ class TestIntegration:
                 mock_pipeline_constructor.assert_called_once_with(
                     name='test_pipeline',
                     db=mock_db,
-                    path='test/output'
+                    path='test/output',
+                    model_name='test-model'
                 )
                 mock_pipeline_instance.update_db_row_table.assert_called_once()
 


### PR DESCRIPTION
The SentenceTransformer model selection in this package is set by default (`jinaai/jina-embeddings-v3`), and it was not possible to modify it. 

For this reason, I added a `model_name` parameter to the `Pipeline`, `SimilarityMatrix`, and `ChunkedSimilarityMatrix` classes, as well as to their related functions. This allows users to specify which SentenceTransformer model to use when computing embeddings.

To test this feature, I created `test_modelname.py`, which verifies different possible scenarios, such as whether the model name is provided or not.

When I ran all the tests, one of them failed. The error produced is as follows:

<pre markdown="1"> FAILED tests/reskill/lib/test_similarity.py::TestCosSimMem::test_max_retries_exceeded - AssertionError: Torch not compiled with CUDA enabled</pre>